### PR TITLE
1-1.管理者登録した後に、従業員一覧に遷移するバグを修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ex-emp-manage-vue-ts-answer",
+      "name": "ex-vue-emp-manage-bugfix-answer",
       "version": "0.1.0",
       "dependencies": {
         "axios": "^0.21.1",

--- a/src/views/RegisterAdmin.vue
+++ b/src/views/RegisterAdmin.vue
@@ -101,7 +101,7 @@ export default class RegisterAdmin extends Vue {
     });
     console.dir("response:" + JSON.stringify(response));
 
-    this.$router.push("/employeeList");
+    this.$router.push("/loginAdmin");
   }
 }
 </script>


### PR DESCRIPTION
登録ボタンを押すと、従業員一覧画面に遷移するバグを修正しました。